### PR TITLE
add gc stats reporting code to process-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ It currently reports these stats:
 * **yourapp.process-reporter.memory-usage.heap-total** total size of v8 heap
 * **yourapp.process-reporter.memory-usage.heap-used** amt of v8 heap used
 * **yourapp.process-reporter.lag-sampler** event loop lag
+* **yourapp.process-reporter.gc.{gc-type}.pause-ms** length of GC pauses
+* **yourapp.process-reporter.gc.{gc-type}.heap-used** amount of bytes GCd
+* **yourapp.process-reporter.gc.{gc-type}.heap-total** changes in heap total
 
 To destroy the reporter just call `processReporter.destroy();`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It currently reports these stats:
 * **yourapp.process-reporter.memory-usage.heap-used** amt of v8 heap used
 * **yourapp.process-reporter.lag-sampler** event loop lag
 * **yourapp.process-reporter.gc.{gc-type}.pause-ms** length of GC pauses
-* **yourapp.process-reporter.gc.{gc-type}.heap-used** amount of bytes GCd
-* **yourapp.process-reporter.gc.{gc-type}.heap-total** changes in heap total
+* **yourapp.process-reporter.gc.{gc-type}.heap-used** +/- amount of bytes GCd
+* **yourapp.process-reporter.gc.{gc-type}.heap-total** +/- changes in heap total
 
 To destroy the reporter just call `processReporter.destroy();`

--- a/index.js
+++ b/index.js
@@ -69,6 +69,11 @@ function ProcessReporter(options) {
     self.memoryTimer = null;
     self.lagTimer = null;
     self.gcStats = null;
+    self._onStatsListener = onStats;
+
+    function onStats(gcInfo) {
+        self._reportGCStats(gcInfo);
+    }
 }
 
 ProcessReporter.prototype.bootstrap = function bootstrap() {
@@ -89,7 +94,7 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
     self.lagTimer = self.timers.setTimeout(onLag, self.lagInterval);
 
     self.gcStats = new _gcstats();
-    self.gcStats.on('stats', onStats);
+    self.gcStats.on('stats', self._onStatsListener);
 
     function onHandle() {
         self._reportHandle();
@@ -113,10 +118,6 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
         self._reportLag();
         self.lagTimer = self.timers.setTimeout(onLag, self.lagInterval);
     }
-
-    function onStats(gcInfo) {
-        self._reportGCStats(gcInfo);
-    }
 };
 
 ProcessReporter.prototype.destroy = function destroy() {
@@ -128,6 +129,7 @@ ProcessReporter.prototype.destroy = function destroy() {
     self.timers.clearTimeout(self.lagTimer);
 
     _toobusy.shutdown();
+    self.gcStats.removeListener('stats', self._onStatsListener);
 };
 
 ProcessReporter.prototype._reportHandle = function _reportHandle() {

--- a/index.js
+++ b/index.js
@@ -115,7 +115,6 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
     }
 
     function onStats(gcInfo) {
-        console.log('!!!!!!!!!!!!1lul', gcInfo);
         self._reportGCStats(gcInfo);
     }
 };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var timers = require('timers');
 var process = require('process');
 var assert = require('assert');
+var _gcstats;
 var _toobusy;
 
 module.exports = ProcessReporter;
@@ -67,6 +68,7 @@ function ProcessReporter(options) {
     self.requestTimer = null;
     self.memoryTimer = null;
     self.lagTimer = null;
+    self.gcStats = null;
 }
 
 ProcessReporter.prototype.bootstrap = function bootstrap() {
@@ -76,11 +78,18 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
         _toobusy = require('toobusy');
     }
 
+    if (!_gcstats) {
+        _gcstats = require('gc-stats');
+    }
+
     self.handleTimer = self.timers.setTimeout(onHandle, self.handleInterval);
     self.requestTimer =
         self.timers.setTimeout(onRequest, self.requestInterval);
     self.memoryTimer = self.timers.setTimeout(onMemory, self.memoryInterval);
     self.lagTimer = self.timers.setTimeout(onLag, self.lagInterval);
+
+    self.gcStats = new _gcstats();
+    self.gcStats.on('stats', onStats);
 
     function onHandle() {
         self._reportHandle();
@@ -103,6 +112,11 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
     function onLag() {
         self._reportLag();
         self.lagTimer = self.timers.setTimeout(onLag, self.lagInterval);
+    }
+
+    function onStats(gcInfo) {
+        console.log('!!!!!!!!!!!!1lul', gcInfo);
+        self._reportGCStats(gcInfo);
     }
 };
 
@@ -162,3 +176,36 @@ ProcessReporter.prototype._reportLag = function _reportLag() {
         _toobusy.lag()
     );
 };
+
+ProcessReporter.prototype._reportGCStats = function _reportGCStats(gcInfo) {
+    var self = this;
+
+    var prefix = self.prefix + 'process-reporter.gc.' + formatGCType(gcInfo);
+
+    self.statsd.timing(prefix + '.pause-ms', gcInfo.pauseMS);
+    self.statsd.gauge(prefix + '.heap-used', gcInfo.diff.usedHeapSize);
+    self.statsd.gauge(prefix + '.heap-total', gcInfo.diff.totalHeapSize);
+};
+
+function formatGCType(gcInfo) {
+    var type;
+    switch (gcInfo.gctype) {
+        case 1:
+            type = 'minor';
+            break;
+
+        case 2:
+            type = 'major';
+            break;
+
+        case 3:
+            type = 'both';
+            break;
+
+        default:
+            type = 'unknown';
+            break;
+    }
+
+    return type;
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Russ Frank <me@russfrank.us>",
   "license": "MIT",
   "dependencies": {
+    "gc-stats": "0.0.6",
     "process": "^0.11.1",
     "toobusy": "^0.2.4"
   },


### PR DESCRIPTION
We add three new stats:
- timing process-reporter.gc.{type}.pause-ms
- gauge process-reporter.gc.{type}.heap-used
- gauge process-reporter.gc.{type}.heap-total

r: @rf @jcorbin
