### PR TITLE
make each reporting feature optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,21 +70,35 @@ function ProcessReporter(options) {
         self.prefix = self.prefix + '.';
     }
 
-    self.handleEnabled = typeof options.handleEnabled === 'boolean' ?
-        options.handleEnabled :
-        true;
-    self.requestEnabled = typeof options.requestEnabled === 'boolean' ?
-        options.requestEnabled :
-        true;
-    self.memoryEnabled = typeof options.memoryEnabled === 'boolean' ?
-        options.memoryEnabled :
-        true;
-    self.lagEnabled = typeof options.lagEnabled === 'boolean' ?
-        options.lagEnabled :
-        true;
-    self.gcEnabled = typeof options.gcEnabled === 'boolean' ?
-        options.gcEnabled :
-        true;
+    if (typeof options.handleEnabled === 'boolean') {
+        self.handleEnabled = options.handleEnabled;
+    } else {
+        self.handleEnabled = true;
+    }
+
+    if (typeof options.requestEnabled === 'boolean') {
+        self.requestEnabled = options.requestEnabled;
+    } else {
+        self.requestEnabled = true;
+    }
+
+    if (typeof options.memoryEnabled === 'boolean') {
+        self.memoryEnabled = options.memoryEnabled;
+    } else {
+        self.memoryEnabled = true;
+    }
+
+    if (typeof options.lagEnabled === 'boolean') {
+        self.lagEnabled = options.lagEnabled;
+    } else {
+        self.lagEnabled = true;
+    }
+
+    if (typeof options.gcEnabled === 'boolean') {
+        self.gcEnabled = options.gcEnabled;
+    } else {
+        self.gcEnabled = true;
+    }
 
     self.handleTimer = null;
     self.requestTimer = null;

--- a/index.js
+++ b/index.js
@@ -197,8 +197,13 @@ ProcessReporter.prototype.destroy = function destroy() {
     self.timers.clearTimeout(self.memoryTimer);
     self.timers.clearTimeout(self.lagTimer);
 
-    _toobusy.shutdown();
-    _gcEmitter.removeListener('stats', self._onStatsListener);
+    if (_toobusy) {
+        _toobusy.shutdown();
+    }
+
+    if (self.gcEnabled) {
+        _gcEmitter.removeListener('stats', self._onStatsListener);
+    }
 };
 
 ProcessReporter.prototype._reportHandle = function _reportHandle() {

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
         );
     }
 
-    if (this.gcEnabled) {
+    if (self.gcEnabled) {
         _gcEmitter.on('stats', self._onStatsListener);
     }
 

--- a/package.json
+++ b/package.json
@@ -6,27 +6,26 @@
   "author": "Russ Frank <me@russfrank.us>",
   "license": "MIT",
   "dependencies": {
-    "bindings": "^1.2.1",
+    "bindings": "1.2.1",
     "gc-stats": "0.0.6",
-    "process": "^0.11.1",
-    "toobusy": "^0.2.4"
+    "process": "0.11.2",
+    "toobusy": "0.2.4"
   },
   "devDependencies": {
-    "format-stack": "^4.1.1",
+    "format-stack": "4.1.1",
     "istanbul": "^0.3.15",
-    "leaked-handles": "^5.2.0",
-    "opn": "^2.0.1",
-    "tape": "^4.0.0",
-    "uber-standard": "^3.7.1"
+    "opn": "3.0.3",
+    "tape": "4.2.2",
+    "uber-standard": "3.7.1"
   },
   "scripts": {
     "check-cover": "istanbul check-coverage || echo coverage failed",
     "check-ls": "npm ls --loglevel=http --parseable 1>/dev/null && echo '# npm is in a good state'",
     "cover": "npm run test-cover -s && npm run check-cover -s",
-    "lint": "standard -v --reporter stylish && echo '# linter passed'",
+    "lint": "uber-standard -v && echo '# linter passed'",
     "test": "npm run check-ls -s && npm run lint -s && npm run cover",
-    "test-cover": "istanbul cover test.js",
-    "view-cover": "opn ./coverage/index.html",
+    "test-cover": "istanbul cover --report html test.js",
+    "view-cover": "opn --no-wait ./coverage/index.html",
     "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)"
   }
 }

--- a/test.js
+++ b/test.js
@@ -122,3 +122,25 @@ test('process reporter disable all', function t(assert) {
     // Don't teardown, test should exit
     assert.end();
 });
+
+test('process reporter disable all safely shuts down', function t(assert) {
+    var reporter = processReporter({
+        handleEnabled: false,
+        requestEnabled: false,
+        memoryEnabled: false,
+        lagEnabled: false,
+        gcEnabled: false,
+        statsd: {}
+    });
+    reporter.bootstrap();
+
+    assert.strictEqual(reporter.handleTimer, null);
+    assert.strictEqual(reporter.requestTimer, null);
+    assert.strictEqual(reporter.memoryTimer, null);
+    assert.strictEqual(reporter.lagTimer, null);
+    assert.strictEqual(reporter._onStatsListener, null);
+
+    reporter.destroy();
+
+    assert.end();
+});

--- a/test.js
+++ b/test.js
@@ -101,3 +101,24 @@ test('processReporter prefix', function t(assert) {
         assert.end();
     }
 });
+
+test('process reporter disable all', function t(assert) {
+    var reporter = processReporter({
+        handleEnabled: false,
+        requestEnabled: false,
+        memoryEnabled: false,
+        lagEnabled: false,
+        gcEnabled: false,
+        statsd: {}
+    });
+    reporter.bootstrap();
+
+    assert.strictEqual(reporter.handleTimer, null);
+    assert.strictEqual(reporter.requestTimer, null);
+    assert.strictEqual(reporter.memoryTimer, null);
+    assert.strictEqual(reporter.lagTimer, null);
+    assert.strictEqual(reporter._onStatsListener, null);
+
+    // Don't teardown, test should exit
+    assert.end();
+});


### PR DESCRIPTION
I want to use the lag sampler in opensource land on it's own and I am concerned about the overheads of the other features in the module. This will allow me to enable lag sampler alone and turn each feature on one by one.

//cc @Raynos 
