### PR TITLE
comply with new linting rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "perf-standard",
+    "globals": {
+        "global": true
+    },
+    "rules": {
+        "spaced-comment": 0,
+        "indent": [2, 4, {
+            "SwitchCase": 1
+        }]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -8,21 +8,22 @@
   "dependencies": {
     "bindings": "1.2.1",
     "gc-stats": "0.0.6",
-    "process": "0.11.2",
     "toobusy": "0.2.4"
   },
   "devDependencies": {
+    "eslint": "1.8.0",
+    "eslint-config-perf-standard": "2.1.0",
+    "eslint-plugin-perf-standard": "1.0.2",
     "format-stack": "4.1.1",
     "istanbul": "^0.3.15",
     "opn": "3.0.3",
-    "tape": "4.2.2",
-    "uber-standard": "3.7.1"
+    "tape": "4.2.2"
   },
   "scripts": {
     "check-cover": "istanbul check-coverage || echo coverage failed",
     "check-ls": "npm ls --loglevel=http --parseable 1>/dev/null && echo '# npm is in a good state'",
     "cover": "npm run test-cover -s && npm run check-cover -s",
-    "lint": "uber-standard -v && echo '# linter passed'",
+    "lint": "eslint $(git ls-files | grep '.js$') && echo '# linter passed'",
     "test": "npm run check-ls -s && npm run lint -s && npm run cover",
     "test-cover": "istanbul cover --report html test.js",
     "view-cover": "opn --no-wait ./coverage/index.html",


### PR DESCRIPTION
This diff updates this module to use `eslint-config-perf-standard`
and follow the new style & performance rules.

r: @rf @Matt-Esch
