### PR TITLE
Use toobusy-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ ProcessReporter.prototype.bootstrap = function bootstrap() {
 
     if (!_toobusy && self.lagEnabled) {
         /*eslint-disable global-require*/
-        _toobusy = require('toobusy');
+        _toobusy = require('toobusy-js');
         /*eslint-enable global-require*/
     }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "gc-stats": "1.0.0",
-    "toobusy": "0.2.4"
+    "toobusy-js": "0.2.4"
   },
   "devDependencies": {
     "eslint": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "gc-stats": "1.0.0",
-    "toobusy-js": "0.2.4"
+    "toobusy-js": "0.4.3"
   },
   "devDependencies": {
     "eslint": "1.8.0",


### PR DESCRIPTION
The dependency toobusy does not build on recent versions of node, toobusy-js is a fork that does. The salient difference is the removal of a native dependency (source of build complications) – and in its place, using unref, a node built in.
