### PR TITLE
Allow passing in a globalStatsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ It currently reports these stats:
 * **yourapp.process-reporter.gc.{gc-type}.heap-total** +/- changes in heap total
 
 To destroy the reporter just call `processReporter.destroy();`
+
+## Docs
+
+The ProcessReporter constructor takes an options dictionary:
+
+ - `options.statsd`, a per-worker statsd to write per-worker stats to
+ - `options.globalStatsd`, a cluster-wide statsd to write cluster-wide stats to
+
+You can pass in an optional `globalStatsd` that will be used to emit
+**lag-sampler** and **gc.{gc-type}.pause-ms** stats that are cluster wide
+so that your statsd aggregation can calculate more accurate P99s
+

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ To destroy the reporter just call `processReporter.destroy();`
 The ProcessReporter constructor takes an options dictionary:
 
  - `options.statsd`, a per-worker statsd to write per-worker stats to
- - `options.globalStatsd`, a cluster-wide statsd to write cluster-wide stats to
+ - `options.clusterStatsd`, a cluster-wide statsd to write cluster-wide stats to
 
-You can pass in an optional `globalStatsd` that will be used to emit
+You can pass in an optional `clusterStatsd` that will be used to emit
 **lag-sampler** and **gc.{gc-type}.pause-ms** stats that are cluster wide
 so that your statsd aggregation can calculate more accurate P99s
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var path = require('path');
 var timers = require('timers');
 var process = global.process;
 var assert = require('assert');

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function ProcessReporter(options) {
     this.statsd = options.statsd;
     assert(typeof this.statsd === 'object', 'options.statsd required');
 
-    this.globalStatsd = options.globalStatsd;
+    this.clusterStatsd = options.clusterStatsd;
 
     this.handleInterval = options.handleInterval || 1000;
     assert(
@@ -252,8 +252,8 @@ ProcessReporter.prototype._reportLag = function _reportLag() {
         lagTime
     );
 
-    if (self.globalStatsd) {
-        self.globalStatsd.timing(
+    if (self.clusterStatsd) {
+        self.clusterStatsd.timing(
             self.prefix + 'process-reporter.lag-sampler',
             lagTime
         );
@@ -269,8 +269,8 @@ ProcessReporter.prototype._reportGCStats = function _reportGCStats(gcInfo) {
     self.statsd.gauge(prefix + '.heap-used', gcInfo.diff.usedHeapSize);
     self.statsd.gauge(prefix + '.heap-total', gcInfo.diff.totalHeapSize);
 
-    if (self.globalStatsd) {
-        self.globalStatsd.timing(prefix + '.pause-ms', gcInfo.pauseMS);
+    if (self.clusterStatsd) {
+        self.clusterStatsd.timing(prefix + '.pause-ms', gcInfo.pauseMS);
     }
 };
 

--- a/test.js
+++ b/test.js
@@ -37,11 +37,11 @@ test('processReporter reports libuv health', function t(assert) {
 
 test('processReport global stats', function t(assert) {
     var workerStatsd = createFakeStatsd();
-    var globalStatsd = createFakeStatsd();
+    var clusterStatsd = createFakeStatsd();
 
     var reporter = processReporter({
         statsd: workerStatsd,
-        globalStatsd: globalStatsd,
+        clusterStatsd: clusterStatsd,
         lagInterval: 10
     });
     reporter.bootstrap();
@@ -52,17 +52,17 @@ test('processReport global stats', function t(assert) {
         reporter.destroy();
 
         var workerRecords = workerStatsd.records;
-        var globalRecords = globalStatsd.records;
+        var clusterRecords = clusterStatsd.records;
 
         assert.equal(workerRecords.length, 1);
-        assert.equal(globalRecords.length, 1);
+        assert.equal(clusterRecords.length, 1);
 
         assert.equal(workerRecords[0].key, 'process-reporter.lag-sampler');
-        assert.equal(globalRecords[0].key, 'process-reporter.lag-sampler');
+        assert.equal(clusterRecords[0].key, 'process-reporter.lag-sampler');
         assert.equal(typeof workerRecords[0].value, 'number');
-        assert.equal(typeof globalRecords[0].value, 'number');
+        assert.equal(typeof clusterRecords[0].value, 'number');
         assert.equal(workerRecords[0].type, 'timing');
-        assert.equal(globalRecords[0].type, 'timing');
+        assert.equal(clusterRecords[0].type, 'timing');
 
         assert.end();
     }


### PR DESCRIPTION
This change allows passing in a `globalStatsd` that
can be configured to be cluster wide and thus allows
the stats aggregation to calculate a cluster wide P99
for lag sampling and gc pause time.

r: @rf @Matt-Esch @kriskowal
