### PR TITLE
feature: Move statsd reporting into seperate class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+package-lock.json


### PR DESCRIPTION
This moves the statsd reporting logic into it's own class.

By factoring this out it's possible to pass in a different
reporter into `ProcessReporter` that supports something other
then statsd ( like prometheus ).